### PR TITLE
CMake enhancement

### DIFF
--- a/src/libraries/GeKo_Gameplay/CMakeLists.txt
+++ b/src/libraries/GeKo_Gameplay/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 2.8)
 include(${CMAKE_MODULE_PATH}/DefaultLibrary.cmake)
 
+file(GLOB_RECURSE HEADER *.h)
+file(GLOB_RECURSE CPP *.cpp)
+SOURCE_GROUP(" " FILES 	${HEADER} ${CPP})
+
 MACRO(SUBDIRLIST result curdir)
   FILE(GLOB children RELATIVE ${curdir} ${curdir}/*)
   SET(dirlist "")

--- a/src/libraries/GeKo_Graphics/CMakeLists.txt
+++ b/src/libraries/GeKo_Graphics/CMakeLists.txt
@@ -1,13 +1,9 @@
 cmake_minimum_required(VERSION 2.8)
 include(${CMAKE_MODULE_PATH}/DefaultLibrary.cmake)
 
-SOURCE_GROUP(" " FILES 	Buffer.h
-						BufferIndex.h
-						Defs.h
-						include.h
-						Window.cpp
-						Window.h
-			)
+file(GLOB_RECURSE HEADER ${CMAKE_CURRENT_SOURCE_DIR} *.h)
+file(GLOB_RECURSE CPP ${CMAKE_CURRENT_SOURCE_DIR} *.cpp)
+SOURCE_GROUP(" " FILES 	${HEADER} ${CPP})
 
 MACRO(SUBDIRLIST result curdir)
   FILE(GLOB children RELATIVE ${curdir} ${curdir}/*)

--- a/src/libraries/GeKo_Graphics/CMakeLists.txt
+++ b/src/libraries/GeKo_Graphics/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 2.8)
 include(${CMAKE_MODULE_PATH}/DefaultLibrary.cmake)
 
-file(GLOB_RECURSE HEADER ${CMAKE_CURRENT_SOURCE_DIR} *.h)
-file(GLOB_RECURSE CPP ${CMAKE_CURRENT_SOURCE_DIR} *.cpp)
+file(GLOB_RECURSE HEADER *.h)
+file(GLOB_RECURSE CPP *.cpp)
 SOURCE_GROUP(" " FILES 	${HEADER} ${CPP})
 
 MACRO(SUBDIRLIST result curdir)


### PR DESCRIPTION
Dateien die direkt im Hauptordner liegen sollen, müssen nun nicht mehr in der CMakeLists.txt aufgeführt werden sondern werden automatisch erkannt.
Die CMakeLists.txt kann jetzt wieder beim Erstellen neuer Geko Komponenten umkopiert werden.
