### PR TITLE
Changes to some Examples, Window and Shaders

### DIFF
--- a/src/executables/Ex_FBO-Depth/main.cpp
+++ b/src/executables/Ex_FBO-Depth/main.cpp
@@ -105,7 +105,7 @@ int main()
 		//ScreenFillingQuad Render Pass
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 		shaderSFQ.bind();
-		shaderSFQ.sendSampler2D("texture", fbo.getDepthTexture());
+		shaderSFQ.sendSampler2D("fboTexture", fbo.getDepthTexture());
 		rect.renderGeometry();
 		shaderSFQ.unbind();
 

--- a/src/executables/Ex_FBO-Stencil/main.cpp
+++ b/src/executables/Ex_FBO-Stencil/main.cpp
@@ -105,7 +105,7 @@ int main()
 		//ScreenFillingQuad Render Pass
 		shaderSFQ.bind();
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-		shaderSFQ.sendSampler2D("texture", fbo.getColorTexture(2));
+		shaderSFQ.sendSampler2D("fboTexture", fbo.getColorTexture(2));
 		rect.renderGeometry();
 		shaderSFQ.unbind();
 

--- a/src/executables/Ex_RealtimeLocalReflections/main.cpp
+++ b/src/executables/Ex_RealtimeLocalReflections/main.cpp
@@ -178,7 +178,7 @@ int main()
 		//ScreenFillingQuad Render Pass
 		shaderSFQ.bind();
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-		shaderSFQ.sendSampler2D("texture", fboSSR.getColorTexture(0));
+		shaderSFQ.sendSampler2D("fboTexture", fboSSR.getColorTexture(0));
 		screenFillingQuad.renderGeometry();
 		shaderSFQ.unbind();
 		

--- a/src/libraries/GeKo_Graphics/Window.cpp
+++ b/src/libraries/GeKo_Graphics/Window.cpp
@@ -52,7 +52,7 @@ GLFWwindow* Window::getWindow(){
 /*
 set the name of the window
 */
-void setName(const char* name)
+void Window::setName(const char* name)
 {
 	m_name = name;
 }
@@ -60,7 +60,7 @@ void setName(const char* name)
 /*
 get the name of the window
 */
-const char* getName()
+const char* Window::getName()
 {
 	return m_name;
 }
@@ -68,7 +68,7 @@ const char* getName()
 /*
 set the width of the window
 */
-void setWidth(int width)
+void Window::setWidth(int width)
 {
 	m_width = width;
 }
@@ -76,7 +76,7 @@ void setWidth(int width)
 /*
 get the width of the window
 */
-int getWidth()
+int Window::getWidth()
 {
 	return m_width;
 }
@@ -84,7 +84,7 @@ int getWidth()
 /*
 set the height of the window
 */
-void setHeight(int height)
+void Window::setHeight(int height)
 {
 	m_height = height;
 }
@@ -92,7 +92,7 @@ void setHeight(int height)
 /*
 get the height of the window
 */
-int getHeight()
+int Window::getHeight()
 {
 	return m_height;
 }
@@ -100,7 +100,7 @@ int getHeight()
 /*
 set the xpos of the window
 */
-void setXpos(int xpos)
+void Window::setXpos(int xpos)
 {
 	m_xpos = xpos;
 }
@@ -108,7 +108,7 @@ void setXpos(int xpos)
 /*
 get the xpos of the window
 */
-int getXpos()
+int Window::getXpos()
 {
 	return m_xpos;
 }
@@ -116,7 +116,7 @@ int getXpos()
 /*
 set the xpos of the window
 */
-void setYpos(int ypos)
+void Window::setYpos(int ypos)
 {
 	m_ypos = ypos;
 }
@@ -124,7 +124,7 @@ void setYpos(int ypos)
 /*
 get the ypos of the window
 */
-int getYpos()
+int Window::getYpos()
 {
 	return m_ypos;
 } 

--- a/src/shaders/GBuffer/GBuffer.frag
+++ b/src/shaders/GBuffer/GBuffer.frag
@@ -1,7 +1,7 @@
 #version 330 core
 
 uniform int useTexture;
-uniform sampler2D texture;
+uniform sampler2D fboTexture;
 
 in vec4 passPosition;
 in vec3 passNormal;
@@ -18,6 +18,6 @@ void main(){
 
 	if (useTexture != 0)
 	{
-		colorOutput = vec4(texture(texture, passUV).rgb, 1.0f);
+		colorOutput = vec4(texture(fboTexture, passUV).rgb, 1.0f);
 	}
 }

--- a/src/shaders/ScreenFillingQuad/screenFillingQuad.frag
+++ b/src/shaders/ScreenFillingQuad/screenFillingQuad.frag
@@ -1,6 +1,6 @@
 #version 330 core
 
-uniform sampler2D texture;
+uniform sampler2D fboTexture;
 
 in vec4 passPosition;
 in vec3 passNormal;
@@ -9,5 +9,5 @@ in vec2 passUV;
 out vec4 fragmentColor;
 
 void main(){ 
-   fragmentColor = texture(texture, passUV);
+   fragmentColor = texture(fboTexture, passUV);
 }


### PR DESCRIPTION
Sampler2D in GBuffer.frag and screenFillingQuad.frag named to fboTexture
from texture. Window.cpp fixed. Examples RealtimeLocalReflections,
Ex_FBO-Depth and Ex-FBO-Stencil changed to match new Sampler2D name
