### PR TITLE
assimp linux fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,20 @@ $ sudo apt-get install libglu1-mesa-dev
 Zwischendurch muss der sudo Befehl einmal mit dem Passwort bestätigt werden.
 Die benötigten Pakete wurden heruntergeladen und installiert.
 
+Weiterhin muss Assimp für Linux per Hand installiert und gebaut werden:
+
+$ git clone git://github.com/assimp/assimp.git assimp 
+
+$ sudo apt-get install libboost-dev 
+$ sudo apt-get install zlib1g-dev 
+
+$ cd assimp 
+$ cmake -G 'Unix Makefiles' 
+$ make 
+$ sudo make install 
+$ sudo ldconfig
+
+
 Hinweis: Sollen für die Dokumentation Graphen erstellt werden muss Graphviz vorher auf dem System installiert sein und die entsprechende Option in CMake ausgewählt werden.
 ($ sudo apt-get graphviz)
 

--- a/README.md
+++ b/README.md
@@ -34,22 +34,33 @@ Ordner gibt, die nicht mit dem GIT synchronisiert werden sollen müssen die ents
 
 Voraussetzung - zum compilen von GLFW werden unter Linux einige Standardpakete benötigt.
 Falls nicht vorhanden, öffne das terminal und gebe folgende Befehle ein:
+
+
 $ sudo apt-get install xorg-dev
+
 $ sudo apt-get install libglu1-mesa-dev
+
+
 Zwischendurch muss der sudo Befehl einmal mit dem Passwort bestätigt werden.
 Die benötigten Pakete wurden heruntergeladen und installiert.
 
 Weiterhin muss Assimp für Linux per Hand installiert und gebaut werden:
 
+
 $ git clone git://github.com/assimp/assimp.git assimp 
 
 $ sudo apt-get install libboost-dev 
+
 $ sudo apt-get install zlib1g-dev 
 
 $ cd assimp 
+
 $ cmake -G 'Unix Makefiles' 
+
 $ make 
+
 $ sudo make install 
+
 $ sudo ldconfig
 
 

--- a/cmake/DefaultProject.cmake
+++ b/cmake/DefaultProject.cmake
@@ -21,7 +21,7 @@ include(${CMAKE_MODULE_PATH}/getOpenAL.cmake)
 
 if("${CMAKE_SYSTEM}" MATCHES "Linux")
 	find_package(X11)
-	set(ALL_LIBRARIES ${ALL_LIBRARIES} ${X11_LIBRARIES} Xrandr Xxf86vm Xi pthread Xcursor Xinerama)
+	set(ALL_LIBRARIES ${ALL_LIBRARIES} ${X11_LIBRARIES} Xrandr Xxf86vm Xi pthread Xcursor Xinerama assimp)
 endif()
 
 

--- a/cmake/getASSIMP.cmake
+++ b/cmake/getASSIMP.cmake
@@ -44,16 +44,13 @@ ELSEIF(APPLE)
 
 ELSEIF("${CMAKE_SYSTEM}" MATCHES "Linux")
 	
-    #set(ASSIMP_INCLUDE_PATH "${CMAKE_SOURCE_DIR}/assimp/src/assimp/include")
+  #set(ASSIMP_INCLUDE_PATH "${CMAKE_SOURCE_DIR}/dependencies/assimp_linux/include")
+  #set(ASSIMP_LIB "${CMAKE_SOURCE_DIR}/dependencies/assimp/libMinGW/libassimp.a")
 
-    #FIND_PATH(ASSIMP_INCLUDE_PATH assimp/defs.h)
-    #FIND_LIBRARY(ASSIMP_LIBRARY
-    #        NAMES assimp
-    #        PATH_SUFFIXES dynamic)
-	#set(ASSIMP_LIB "${ASSIMP_LIBRARY}")
-
- 	set(ASSIMP_INCLUDE_PATH "${CMAKE_SOURCE_DIR}/dependencies/assimp/include/")
-	set(ASSIMP_LIB "${CMAKE_SOURCE_DIR}/dependencies/assimp/libMinGW/libassimp.a")
+  FIND_PATH(ASSIMP_INCLUDE_PATH assimp/defs.h)
+  FIND_LIBRARY(ASSIMP_LIBRARY
+       NAMES assimp
+	)
 
 #ELSE()
 


### PR DESCRIPTION
Assimp konnte unter Linux nicht funktionieren. War bisher noch nicht aufgefallen, da ich unter Linux Assimp noch nicht getestet hatte. Sollte jetzt aber vorerst behoben sein. 
Leider muss Assimp jetzt momentan unter Linux noch per Hand kompiliert werden, damit cmake funktioniert (@MaikKlein)

$ git clone git://github.com/assimp/assimp.git assimp
$ sudo apt-get install libboost-dev  (falls nicht schon vorhanden)
$ sudo apt-get install zlib1g-dev     (falls nicht schon vorhanden)
$ cd assimp
$ cmake -G 'Unix Makefiles'
$ make
$ sudo make install
$ sudo ldconfig
